### PR TITLE
FIX: Account information clipboard icons do nothing

### DIFF
--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/FinalizeAccountCreationScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/FinalizeAccountCreationScreen.kt
@@ -26,6 +26,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import android.content.ClipboardManager
+import android.content.ClipData
+import android.widget.Toast
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.core.graphics.toColorInt
 import com.example.walletapp.R
 
@@ -87,24 +91,28 @@ fun FinalizeAccountCreationScreen(onContinue: () -> Unit) {
 
 @Composable
 fun AccountInfoView(onContinue: () -> Unit) {
-
-    val context = (LocalContext.current as Activity)
+    val context = LocalContext.current as Activity
+    val clipboardManager = LocalContext.current.getSystemService(ClipboardManager::class.java)
 
     var checked by remember { mutableStateOf(true) }
+    val accountName = "Starknet"
+    val privateKey = "q78ggh277ibckewjtnM"
 
-
-    Column (
+    Column(
         verticalArrangement = Arrangement.Center,
         modifier = Modifier.padding(16.dp)
-
     ) {
-
-    Text(text=  "Account Information", style = TextStyle(color = Color.White, fontWeight = FontWeight.ExtraBold, fontSize = 22.sp))
+        Text(
+            text = "Account Information",
+            style = TextStyle(color = Color.White, fontWeight = FontWeight.ExtraBold, fontSize = 22.sp)
+        )
         Spacer(modifier = Modifier.height(10.dp))
-        Card (
+
+        Card(
             backgroundColor = Color("#141462".toColorInt()),
             shape = RoundedCornerShape(size = 8.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .background(color = Color("#141462".toColorInt()))
                 .padding(top = 15.dp, start = 15.dp, end = 15.dp, bottom = 15.dp)
         ) {
@@ -113,31 +121,27 @@ fun AccountInfoView(onContinue: () -> Unit) {
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Box(){
-                        Column {
-                            Text(text=  "Account name", style = TextStyle(color = Color("#8D8DBB".toColorInt()), fontWeight = FontWeight.Medium, fontSize = 15.sp))
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(text=  "Starknet", style = TextStyle(color = Color.White, fontWeight = FontWeight.Medium, fontSize = 15.sp))
-
-                        }
+                    Column {
+                        Text(
+                            text = "Account name",
+                            style = TextStyle(color = Color("#8D8DBB".toColorInt()), fontWeight = FontWeight.Medium, fontSize = 15.sp)
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = accountName,
+                            style = TextStyle(color = Color.White, fontWeight = FontWeight.Medium, fontSize = 15.sp)
+                        )
                     }
-
-                    Box(
-                        modifier = Modifier
-                            .width(30.dp)
-                            .height(30.dp)
-                            .background(color = Color.Transparent)
-                            .border(width = 1.dp, color = Color.White, shape = RoundedCornerShape(4.dp))
-                            .padding(4.dp),
-                    ) {
+                    IconButton(onClick = {
+                        clipboardManager.setPrimaryClip(ClipData.newPlainText("Account Name", accountName))
+                        Toast.makeText(context, "Account name copied", Toast.LENGTH_SHORT).show()
+                    }) {
                         Image(
                             painter = painterResource(id = R.drawable.content_copy),
                             contentDescription = "Copy",
                             modifier = Modifier.size(20.dp)
                         )
                     }
-
-
                 }
 
                 Spacer(modifier = Modifier.height(30.dp))
@@ -146,39 +150,33 @@ fun AccountInfoView(onContinue: () -> Unit) {
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Box(){
-                        Column {
-                            Text(text=  "Private key", style = TextStyle(color = Color("#8D8DBB".toColorInt()), fontWeight = FontWeight.Medium, fontSize = 15.sp))
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(text=  "q78ggh277ibckewjtnM", style = TextStyle(color = Color.White, fontWeight = FontWeight.Medium, fontSize = 15.sp))
-
-                        }
+                    Column {
+                        Text(
+                            text = "Private key",
+                            style = TextStyle(color = Color("#8D8DBB".toColorInt()), fontWeight = FontWeight.Medium, fontSize = 15.sp)
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = privateKey,
+                            style = TextStyle(color = Color.White, fontWeight = FontWeight.Medium, fontSize = 15.sp)
+                        )
                     }
-
-
-                    Box(
-                        modifier = Modifier
-                            .width(30.dp)
-                            .height(30.dp)
-                            .background(color = Color.Transparent)
-                            .border(width = 1.dp, color = Color.White, shape = RoundedCornerShape(4.dp))
-                            .padding(4.dp),
-                    ) {
+                    IconButton(onClick = {
+                        clipboardManager.setPrimaryClip(ClipData.newPlainText("Private Key", privateKey))
+                        Toast.makeText(context, "Private key copied", Toast.LENGTH_SHORT).show()
+                    }) {
                         Image(
                             painter = painterResource(id = R.drawable.content_copy),
                             contentDescription = "Copy",
-                            modifier = Modifier
-                                .size(20.dp)
+                            modifier = Modifier.size(20.dp)
                         )
                     }
-
-
-
                 }
             }
         }
 
         Spacer(modifier = Modifier.height(30.dp))
+
         Button(
             onClick = {},
             colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt()), contentColor = Color.White),
@@ -186,61 +184,46 @@ fun AccountInfoView(onContinue: () -> Unit) {
                 .background(color = Color("#141462".toColorInt()))
                 .height(51.dp)
                 .border(width = 1.dp, color = Color("#1B1B76".toColorInt()), shape = RoundedCornerShape(8.dp))
-
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-
-
-            ){
-
-                Icon(
-                    imageVector = Icons.Filled.Refresh,
-                    contentDescription = "Backward  Arrow",
-                    modifier = Modifier.padding(start = 8.dp),
-                    tint = Color.White
-                )
-
-                Spacer(modifier = Modifier.width(10.dp))
-
-                Text(text = "Generate new private key", style = TextStyle(color = Color("#A3A3C1".toColorInt()),  fontSize = 16.sp, fontWeight = FontWeight.Medium))
-            }
-        }
-
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-
-
-        Button(
-            onClick = { /* TOOD */ },
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt()), contentColor = Color.White),
-            modifier = Modifier.fillMaxWidth()
-                .background(color = Color("#1B1B76".toColorInt()))
-                .height(51.dp)
-                .border(width = 1.dp, color = Color("#CBC5C5".toColorInt()), shape = RoundedCornerShape(8.dp))
-
-
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
-            ){
-
+            ) {
                 Icon(
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = "Backward  Arrow",
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = "Generate new key",
                     modifier = Modifier.padding(start = 8.dp),
                     tint = Color.White
                 )
-
                 Spacer(modifier = Modifier.width(10.dp))
+                Text(text = "Generate new private key", style = TextStyle(color = Color("#A3A3C1".toColorInt()), fontSize = 16.sp, fontWeight = FontWeight.Medium))
+            }
+        }
 
-                Text(text = "Use existing private key", style = TextStyle(color = Color.White, fontSize = 16.sp,
-                    fontWeight = FontWeight.Medium))
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = { /* TODO */ },
+            colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt()), contentColor = Color.White),
+            modifier = Modifier.fillMaxWidth()
+                .background(color = Color("#1B1B76".toColorInt()))
+                .height(51.dp)
+                .border(width = 1.dp, color = Color("#CBC5C5".toColorInt()), shape = RoundedCornerShape(8.dp))
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = "Use existing key",
+                    modifier = Modifier.padding(start = 8.dp),
+                    tint = Color.White
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(text = "Use existing private key", style = TextStyle(color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Medium))
             }
         }
 
@@ -248,26 +231,18 @@ fun AccountInfoView(onContinue: () -> Unit) {
 
         Box(
             modifier = Modifier
-                .background(color = Color("#221451".toColorInt(), ))
+                .background(color = Color("#221451".toColorInt()))
                 .height(74.dp)
                 .border(width = 1.dp, color = Color("#221451".toColorInt()), shape = RoundedCornerShape(16.dp))
                 .padding(16.dp)
-
-        ){
-            Row(){
-
-
+        ) {
+            Row {
                 Icon(
                     imageVector = Icons.Outlined.Info,
                     contentDescription = "Info",
                     tint = Color("#E45F61".toColorInt())
                 )
-
-
                 Spacer(modifier = Modifier.width(10.dp))
-
-
-
                 Text(
                     text = "Store your private key securely. In case of its lost or stolen, access to funds will be lost without the possibility of recovery",
                     style = TextStyle(color = Color("#E45F61".toColorInt()), fontSize = 14.sp)
@@ -275,16 +250,9 @@ fun AccountInfoView(onContinue: () -> Unit) {
             }
         }
 
-
         Spacer(modifier = Modifier.height(20.dp))
 
-
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-
-        ) {
-
+        Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(
                 modifier = Modifier.border(width = 1.dp, color = Color("#54DC84".toColorInt()), shape = RoundedCornerShape(30.dp))
                     .height(25.dp)
@@ -292,10 +260,7 @@ fun AccountInfoView(onContinue: () -> Unit) {
                 checked = checked,
                 onCheckedChange = { checked = it },
                 colors = CheckboxDefaults.colors(checkedColor = Color.Transparent, checkmarkColor = Color("#54DC84".toColorInt())),
-
             )
-
-
             Spacer(modifier = Modifier.width(10.dp))
             Text(
                 "I have read the information and saved the private key",
@@ -303,10 +268,8 @@ fun AccountInfoView(onContinue: () -> Unit) {
             )
         }
 
-
         Spacer(modifier = Modifier.weight(1f))
 
-        // TODO(#109): pressing continue on this screen should save the account information to the device
         Button(
             onClick = onContinue,
             contentPadding = ButtonDefaults.ContentPadding,
@@ -316,9 +279,7 @@ fun AccountInfoView(onContinue: () -> Unit) {
                 .fillMaxWidth()
                 .height(49.dp)
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Text("Continue")
                 Icon(
                     imageVector = Icons.Filled.ArrowForward,
@@ -329,17 +290,6 @@ fun AccountInfoView(onContinue: () -> Unit) {
             }
         }
 
-
         Spacer(modifier = Modifier.height(20.dp))
-
-
     }
-
 }
-
-
-
-
-
-
-


### PR DESCRIPTION
- [x] issue #103 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/starknet-phone/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests
- [ ] breaking change

##Description

Made a fix to the clipboard icons that let users copy text using the icon, after copying, a toast message appears saying it was copied to let the user know the action was successful, also I cleaned a bit the `AccountInfoView` func 

#Screenshots

![image](https://github.com/user-attachments/assets/bdc89bc7-3b19-4823-92cf-bf49a0d605e2)
![image](https://github.com/user-attachments/assets/962a2a30-9111-4d39-99d7-2acfe55b048c)

