### PR TITLE
feat: change material imports to material3

### DIFF
--- a/wallet_app/app/build.gradle.kts
+++ b/wallet_app/app/build.gradle.kts
@@ -103,8 +103,6 @@ dependencies {
 
     // Material Design 3
     implementation(libs.androidx.material3)
-    // or Material Design 2
-    implementation(libs.androidx.material)
 
     // Retrofit for network requests
     implementation(libs.retrofit)

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/account/AddTokenScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/account/AddTokenScreen.kt
@@ -11,12 +11,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -141,8 +142,9 @@ fun AddTokenScreen(tokenViewModel:TokenViewModel,onConfirm: () -> Unit) {
                         Toast.makeText(context, "Token added!", Toast.LENGTH_LONG).show()
                     }
                 },
-                colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt())),
-                modifier = Modifier
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color("#1B1B76".toColorInt())
+                ), modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 30.dp, end = 30.dp)
             ) {
@@ -173,12 +175,15 @@ fun SimpleTextField(
             value = value,
             onValueChange = onValueChange,
             placeholder = { Text(text = placeholder) },
-            colors = TextFieldDefaults.outlinedTextFieldColors(
-                backgroundColor = Color("#1B1B76".toColorInt()),
-                focusedBorderColor = Color.Transparent,
+            colors = OutlinedTextFieldDefaults.colors(
+                unfocusedContainerColor = Color("#1B1B76".toColorInt()),
+                focusedContainerColor = Color("#1B1B76".toColorInt()),
                 unfocusedBorderColor = Color.Transparent,
-                textColor = Color.Black,
-                placeholderColor = Color("#A9A9A9".toColorInt())
+                focusedBorderColor = Color.Transparent,
+                unfocusedTextColor = Color.Black,
+                focusedTextColor = Color.Black,
+                unfocusedPlaceholderColor = Color("#A9A9A9".toColorInt()),
+                focusedPlaceholderColor = Color("#A9A9A9".toColorInt())
             ),
             shape = RoundedCornerShape(15.dp),
             modifier = Modifier.fillMaxWidth(),

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/account/WalletScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/account/WalletScreen.kt
@@ -151,7 +151,7 @@ fun Wallet(modifier: Modifier, onNewTokenPress: () -> Unit, onReceivePress: () -
     if (errorMessage.isNotEmpty()) {
         Text(
             text = errorMessage,
-            color = MaterialTheme.colors.error,
+            color = MaterialTheme.colorScheme.error,
             modifier = Modifier.padding(16.dp)
         )
     } else {
@@ -261,7 +261,9 @@ fun Wallet(modifier: Modifier, onNewTokenPress: () -> Unit, onReceivePress: () -
         ) {
             Button(
                 onClick = onReceivePress,
-                colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt())),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color("#1B1B76".toColorInt())
+                ),
                 shape = RoundedCornerShape(15.dp),
             ) {
                 Text(
@@ -272,8 +274,9 @@ fun Wallet(modifier: Modifier, onNewTokenPress: () -> Unit, onReceivePress: () -
             }
             Button(
                 onClick = onSendPress,
-
-                colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt())),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color("#1B1B76".toColorInt())
+                ),
                 shape = RoundedCornerShape(15.dp),
             ) {
                 Text(
@@ -291,7 +294,9 @@ fun Wallet(modifier: Modifier, onNewTokenPress: () -> Unit, onReceivePress: () -
 @Composable
 fun WalletCard(imageUrl: String,name:String, amount: String, balance: String, type: String) {
     Card(
-        backgroundColor = Color(0xFF1E1E96),
+        colors = CardDefaults.cardColors(
+            containerColor = Color(0xFF1E1E96)
+        ),
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/account/WalletScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/account/WalletScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Card
-import androidx.compose.material.Surface
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -39,7 +39,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.graphics.toColorInt
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/CreateAccountScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/CreateAccountScreen.kt
@@ -16,15 +16,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -137,6 +136,7 @@ fun CreateAccountScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateWallet(modifier: Modifier = Modifier, onNext: () -> Unit) {
     val borderColor = Color("#1B1B76".toColorInt())
@@ -185,10 +185,11 @@ fun CreateWallet(modifier: Modifier = Modifier, onNext: () -> Unit) {
                     ,
                     shape = RoundedCornerShape(8.dp),
                     colors = TextFieldDefaults.outlinedTextFieldColors(
-                        backgroundColor = Color(0xFF1B1B76),
+                        containerColor = Color(0xFF1B1B76),
                         focusedBorderColor = borderColor,
-                        textColor = Color.White,
-                        unfocusedBorderColor = borderColor
+                        unfocusedBorderColor = borderColor,
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White
                     )
                 )
             }
@@ -199,7 +200,10 @@ fun CreateWallet(modifier: Modifier = Modifier, onNext: () -> Unit) {
             onClick = { onNext()  },
             contentPadding = ButtonDefaults.ContentPadding,
             shape = RoundedCornerShape(8.dp),
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color("#EC796B".toColorInt()), contentColor = Color.White),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color("#EC796B".toColorInt()),
+                contentColor = Color.White
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(49.dp)
@@ -220,7 +224,7 @@ fun CreateWallet(modifier: Modifier = Modifier, onNext: () -> Unit) {
 }
 
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GenerateKey(modifier: Modifier = Modifier, onContinue: () -> Unit) {
     val scope = rememberCoroutineScope()
@@ -258,7 +262,7 @@ fun GenerateKey(modifier: Modifier = Modifier, onContinue: () -> Unit) {
             contentPadding = ButtonDefaults.ContentPadding,
             shape = RoundedCornerShape(8.dp),
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = Color("#EC796B".toColorInt()),
+                containerColor = Color("#EC796B".toColorInt()),
                 contentColor = Color.White
             ),
             modifier = Modifier
@@ -297,7 +301,7 @@ fun GenerateKey(modifier: Modifier = Modifier, onContinue: () -> Unit) {
 
 
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GeneratekeySheet(
     openBottomSheet: Boolean,
@@ -345,8 +349,10 @@ fun GeneratekeySheet(
                     onClick = onContinue,
                     contentPadding = ButtonDefaults.ContentPadding,
                     shape = RoundedCornerShape(8.dp),
-                    colors = ButtonDefaults.buttonColors(backgroundColor = Color("#EC796B".toColorInt()), contentColor = Color.White),
-                    modifier = Modifier
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color("#EC796B".toColorInt()),
+                        contentColor = Color.White
+                    ), modifier = Modifier
                         .fillMaxWidth()
                         .height(49.dp)
                 ) {

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/CreateAccountScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/CreateAccountScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -53,6 +54,7 @@ import androidx.core.graphics.toColorInt
 import com.example.walletapp.R
 import kotlinx.coroutines.CoroutineScope
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateAccountScreen(
     onContinue: () -> Unit
@@ -61,39 +63,20 @@ fun CreateAccountScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                backgroundColor = Color("#0C0C4F".toColorInt()),
-                contentColor = Color.White,
-                elevation = 4.dp
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 32.dp, start = 16.dp, end = 16.dp),
-
-                    ) {
-                    // TODO(#100): add back navigation
+                title = { Text("Create Account", color = Color.White, fontSize = 20.sp) },
+                navigationIcon = {
                     Icon(
                         imageVector = Icons.Filled.ArrowBack,
-                        contentDescription = "Backward  Arrow",
+                        contentDescription = "Backward Arrow",
                         modifier = Modifier.padding(start = 8.dp),
                         tint = Color.White
                     )
-
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-
-                        Text(
-                            text = "Create Account",
-                            color = Color.White,
-                            fontSize = 20.sp
-                        )
-
-                    }
-
-                }
-            }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color("#0C0C4F".toColorInt()),
+                    titleContentColor = Color.White
+                )
+            )
         }
     ) { paddingValues ->
         Column(
@@ -101,14 +84,16 @@ fun CreateAccountScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
                 .background(color = Color("#0C0C4F".toColorInt()))
-                .padding(top = 30.dp, start = 16.dp, end = 16.dp )
-
+                .padding(top = 30.dp, start = 16.dp, end = 16.dp)
         ) {
-
             Text(
                 text = if (progress < 1.0f) "1 of 2" else "2 of 2",
-                style = TextStyle(color = Color("#EC796B".toColorInt()), fontWeight = FontWeight.ExtraBold, fontSize = 16.sp, textAlign = TextAlign.Center )
-
+                style = TextStyle(
+                    color = Color("#EC796B".toColorInt()),
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 16.sp,
+                    textAlign = TextAlign.Center
+                )
             )
 
             Spacer(modifier = Modifier.height(5.dp))
@@ -116,8 +101,6 @@ fun CreateAccountScreen(
                 progress = progress,
                 modifier = Modifier.fillMaxWidth(),
                 color = Color("#EC796B".toColorInt())
-
-
             )
 
             if (progress < 1.0f) {
@@ -128,13 +111,15 @@ fun CreateAccountScreen(
                     }
                 )
             } else {
-                GenerateKey(modifier = Modifier.padding(top = 16.dp), onContinue)
+                GenerateKey(
+                    modifier = Modifier.padding(top = 16.dp),
+                    onContinue
+                )
             }
-
-
         }
     }
 }
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/CreatePinScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/CreatePinScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
@@ -126,7 +126,7 @@ fun CreatePinScreen(onContinue: () -> Unit) {
                 contentPadding = ButtonDefaults.ContentPadding,
                 shape = RoundedCornerShape(8.dp),
                 colors = ButtonDefaults.buttonColors(
-                    backgroundColor = Color("#EC796B".toColorInt()),
+                    containerColor = Color("#EC796B".toColorInt()),
                     contentColor = Color.White
                 ),
                 modifier = Modifier
@@ -227,7 +227,10 @@ fun NumericKeypad(onDigitClick: (String) -> Unit, onDeleteClick: () -> Unit) {
 fun KeypadButton(text: String, onClick: () -> Unit) {
     Button(
         onClick = onClick,
-        colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt()), contentColor = Color.White),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color("#1B1B76".toColorInt()),
+            contentColor = Color.White
+        ),
         shape = CircleShape,
                 modifier = Modifier
             .size(50.dp)

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/FinalizeAccountCreationScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/FinalizeAccountCreationScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
@@ -109,7 +109,9 @@ fun AccountInfoView(onContinue: () -> Unit) {
         Spacer(modifier = Modifier.height(10.dp))
 
         Card(
-            backgroundColor = Color("#141462".toColorInt()),
+            colors = CardDefaults.cardColors(
+                containerColor = Color("#141462".toColorInt())
+            ),
             shape = RoundedCornerShape(size = 8.dp),
             modifier = Modifier
                 .fillMaxWidth()
@@ -179,7 +181,10 @@ fun AccountInfoView(onContinue: () -> Unit) {
 
         Button(
             onClick = {},
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt()), contentColor = Color.White),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color("#1B1B76".toColorInt()),
+                contentColor = Color.White
+            ),
             modifier = Modifier.fillMaxWidth()
                 .background(color = Color("#141462".toColorInt()))
                 .height(51.dp)
@@ -205,7 +210,10 @@ fun AccountInfoView(onContinue: () -> Unit) {
 
         Button(
             onClick = { /* TODO */ },
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt()), contentColor = Color.White),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color("#1B1B76".toColorInt()),
+                contentColor = Color.White
+            ),
             modifier = Modifier.fillMaxWidth()
                 .background(color = Color("#1B1B76".toColorInt()))
                 .height(51.dp)
@@ -274,7 +282,10 @@ fun AccountInfoView(onContinue: () -> Unit) {
             onClick = onContinue,
             contentPadding = ButtonDefaults.ContentPadding,
             shape = RoundedCornerShape(8.dp),
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color("#EC796B".toColorInt()), contentColor = Color.White),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color("#EC796B".toColorInt()),
+                contentColor = Color.White
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(49.dp)

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/FinalizeAccountCreationScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/FinalizeAccountCreationScreen.kt
@@ -33,43 +33,26 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.core.graphics.toColorInt
 import com.example.walletapp.R
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FinalizeAccountCreationScreen(onContinue: () -> Unit) {
     Scaffold(
         topBar = {
             TopAppBar(
-                backgroundColor = Color("#0C0C4F".toColorInt()),
-                contentColor = Color.White,
-                elevation = 4.dp
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 32.dp, start = 16.dp, end = 16.dp),
-
-                    ) {
-                    // TODO(#100): add back navigation
+                title = { Text("Create Account", color = Color.White, fontSize = 20.sp) },
+                navigationIcon = {
                     Icon(
                         imageVector = Icons.Filled.ArrowBack,
-                        contentDescription = "Backward  Arrow",
+                        contentDescription = "Backward Arrow",
                         modifier = Modifier.padding(start = 8.dp),
                         tint = Color.White
                     )
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-
-                        Text(
-                            text = "Create Account",
-                            color = Color.White,
-                            fontSize = 20.sp
-                        )
-
-                    }
-
-                }
-            }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color("#0C0C4F".toColorInt()),
+                    titleContentColor = Color.White
+                )
+            )
         }
     ) { paddingValues ->
         Column(
@@ -77,17 +60,14 @@ fun FinalizeAccountCreationScreen(onContinue: () -> Unit) {
                 .fillMaxSize()
                 .padding(paddingValues)
                 .background(color = Color("#0C0C4F".toColorInt()))
-                .padding(top = 50.dp, start = 16.dp, end = 16.dp )
-
+                .padding(top = 50.dp, start = 16.dp, end = 16.dp)
         ) {
-
             Spacer(modifier = Modifier.height(5.dp))
             AccountInfoView(onContinue)
-
-
         }
     }
 }
+
 
 @Composable
 fun AccountInfoView(onContinue: () -> Unit) {

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/ImportAccountScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/ImportAccountScreen.kt
@@ -16,23 +16,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -134,7 +133,7 @@ fun ImportAccountScreen( onFinishAccountImport: () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 
 @Composable
 fun PrivateKeyView(modifier: Modifier = Modifier, onNext: () -> Unit) {
@@ -182,10 +181,11 @@ fun PrivateKeyView(modifier: Modifier = Modifier, onNext: () -> Unit) {
                         .background(Color.Transparent),
                     shape = RoundedCornerShape(8.dp),
                     colors = TextFieldDefaults.outlinedTextFieldColors(
-                        backgroundColor = Color(0xFF1B1B76),
+                        containerColor = Color(0xFF1B1B76),
                         focusedBorderColor = borderColor,
-                        textColor = Color.White,
-                        unfocusedBorderColor = borderColor
+                        unfocusedBorderColor = borderColor,
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White
                     )
                 )
             }
@@ -197,7 +197,10 @@ fun PrivateKeyView(modifier: Modifier = Modifier, onNext: () -> Unit) {
             onClick = onNext,
             contentPadding = ButtonDefaults.ContentPadding,
             shape = RoundedCornerShape(8.dp),
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color("#EC796B".toColorInt()), contentColor = Color.White),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color("#EC796B".toColorInt()),
+                contentColor = Color.White
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(49.dp)
@@ -219,7 +222,7 @@ fun PrivateKeyView(modifier: Modifier = Modifier, onNext: () -> Unit) {
 
 
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateNameView(modifier: Modifier = Modifier, onFinishAccountImport: () -> Unit) {
     val borderColor = Color("#1B1B76".toColorInt())
@@ -261,8 +264,9 @@ fun CreateNameView(modifier: Modifier = Modifier, onFinishAccountImport: () -> U
                     .background(Color.Transparent),
                 shape = RoundedCornerShape(8.dp),
                 colors = TextFieldDefaults.outlinedTextFieldColors(
-                    backgroundColor = Color(0xFF1B1B76),
-                    textColor = Color.White,
+                    containerColor = Color(0xFF1B1B76),
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
                     focusedBorderColor = borderColor,
                     unfocusedBorderColor = borderColor
                 )
@@ -280,7 +284,7 @@ fun CreateNameView(modifier: Modifier = Modifier, onFinishAccountImport: () -> U
             contentPadding = ButtonDefaults.ContentPadding,
             shape = RoundedCornerShape(8.dp),
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = Color("#EC796B".toColorInt()),
+                containerColor = Color("#EC796B".toColorInt()),
                 contentColor = Color.White
             ),
             modifier = Modifier

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/ImportAccountScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/onboarding/ImportAccountScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -32,6 +32,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,45 +53,27 @@ import androidx.core.graphics.toColorInt
 import com.example.walletapp.R
 import kotlinx.coroutines.CoroutineScope
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ImportAccountScreen( onFinishAccountImport: () -> Unit) {
+fun ImportAccountScreen(onFinishAccountImport: () -> Unit) {
     var progress by remember { mutableStateOf(0.5f) }
     Scaffold(
         topBar = {
             TopAppBar(
-                backgroundColor = Color("#0C0C4F".toColorInt()),
-                contentColor = Color.White,
-                elevation = 4.dp
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 32.dp, start = 16.dp, end = 16.dp),
-
-                    ) {
-                    // TODO(#100): add back navigation
+                title = { Text("Import existing wallet", color = Color.White, fontSize = 20.sp) },
+                navigationIcon = {
                     Icon(
                         imageVector = Icons.Filled.ArrowBack,
-                        contentDescription = "Backward  Arrow",
+                        contentDescription = "Backward Arrow",
                         modifier = Modifier.padding(start = 8.dp),
                         tint = Color.White
                     )
-
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-
-                        Text(
-                            text = "Import existing wallet",
-                            color = Color.White,
-                            fontSize = 20.sp
-                        )
-
-                    }
-
-                }
-            }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color("#0C0C4F".toColorInt()),
+                    titleContentColor = Color.White
+                )
+            )
         }
     ) { paddingValues ->
         Column(
@@ -98,14 +81,16 @@ fun ImportAccountScreen( onFinishAccountImport: () -> Unit) {
                 .fillMaxSize()
                 .padding(paddingValues)
                 .background(color = Color("#0C0C4F".toColorInt()))
-                .padding(top = 30.dp, start = 16.dp, end = 16.dp )
-
+                .padding(top = 30.dp, start = 16.dp, end = 16.dp)
         ) {
-
             Text(
                 text = if (progress < 1.0f) "1 of 2" else "2 of 2",
-                style = TextStyle(color = Color("#EC796B".toColorInt()), fontWeight = FontWeight.ExtraBold, fontSize = 16.sp, textAlign = TextAlign.Center )
-
+                style = TextStyle(
+                    color = Color("#EC796B".toColorInt()),
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 16.sp,
+                    textAlign = TextAlign.Center
+                )
             )
 
             Spacer(modifier = Modifier.height(5.dp))
@@ -113,8 +98,6 @@ fun ImportAccountScreen( onFinishAccountImport: () -> Unit) {
                 progress = progress,
                 modifier = Modifier.fillMaxWidth(),
                 color = Color("#EC796B".toColorInt())
-
-
             )
 
             if (progress < 1.0f) {
@@ -125,13 +108,15 @@ fun ImportAccountScreen( onFinishAccountImport: () -> Unit) {
                     }
                 )
             } else {
-                CreateNameView(modifier = Modifier.padding(top = 16.dp), onFinishAccountImport)
+                CreateNameView(
+                    modifier = Modifier.padding(top = 16.dp),
+                    onFinishAccountImport
+                )
             }
-
-
         }
     }
 }
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/transfer/ReceiveScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/transfer/ReceiveScreen.kt
@@ -12,8 +12,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/wallet_app/app/src/main/java/com/example/walletapp/ui/transfer/SendScreen.kt
+++ b/wallet_app/app/src/main/java/com/example/walletapp/ui/transfer/SendScreen.kt
@@ -12,12 +12,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Icon
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
@@ -61,7 +61,7 @@ fun SendScreen() {
             // Dropdown button for selecting currency
             Button(
                 onClick = { /* Handle currency selection */ },
-                colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFF1E1E96)),
+                colors = ButtonDefaults.buttonColors(containerColor  = Color(0xFF1E1E96)),
                 modifier = Modifier.padding(8.dp)
             ) {
                 Image(
@@ -114,7 +114,7 @@ fun SendScreen() {
             // Confirm Button
             Button(
                 onClick = { /* Handle confirm action */ },
-                colors = ButtonDefaults.buttonColors(backgroundColor = Color("#1B1B76".toColorInt())),
+                colors = ButtonDefaults.buttonColors(containerColor  = Color("#1B1B76".toColorInt())),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 30.dp, end = 30.dp)


### PR DESCRIPTION
### [feat] Change all material imports to material3

- [x] issue #105 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/starknet-phone/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests (Not applicable for this PR as it involves UI refactor)
- [ ] breaking change (No breaking changes introduced)

<!-- PR description below -->

### Description

This PR migrates all relevant UI components from Material to Material3 and removes the Material dependency from the project. Specifically, I applied the following changes:

- Replaced `TopAppBar` in multiple screens (`FinalizeAccountCreationScreen`, `ImportAccountScreen`, `CreateAccountScreen`) with the Material3 `TopAppBar`.
- Updated `Button`, `TextField`, and `Card` components to align with Material3 API, adjusting colors and removing deprecated parameters like `backgroundColor` and `elevation`.
- Removed `androidx.compose.material:material` dependency from the `build.gradle.kts` file.