### PR TITLE
fix: replace which with command -v for java detection

### DIFF
--- a/examples/DappExample/gradlew
+++ b/examples/DappExample/gradlew
@@ -99,7 +99,7 @@ location of your Java installation."
     fi
 else
     JAVACMD="java"
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    command -v java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."


### PR DESCRIPTION
Use POSIX-compliant command -v instead of which for Java detection to improve portability across environments
